### PR TITLE
Add more `derive` traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,7 @@ impl DurationBreakdown {
 /// These durations do not account for variations in the potential unit based on the current time.
 /// Perhaps in a future release.
 ///
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FancyDuration<D: AsTimes + Clone>(pub D);
 
 impl<D> FancyDuration<D>


### PR DESCRIPTION
This pull request adds more `derive` traits (`Copy`, `Default`, `Eq`, `PartialOrd`, `Ord` and `Hash`) to `FancyDuration`.

These additions aim to improve compatibility and usability when `FancyDuration` is directly instantiated within `struct`s involving common derive usage patterns.